### PR TITLE
style: use consistent quote marks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,48 +1,49 @@
 module.exports = {
   pathPrefix: '/axrl',
   siteMetadata: {
-    title: `AXRL: Accessibility Report Language`,
-    description: `A data format for ICT accessibility testing`,
-    author: `Wilco Fiers`,
+    title: 'AXRL: Accessibility Report Language',
+    description:
+      'A data format for ICT accessibility testing',
+    author: 'Wilco Fiers',
     lang: 'en-US'
   },
   plugins: [
-    `gatsby-plugin-react-helmet`,
-    `schema-types`,
+    'gatsby-plugin-react-helmet',
+    'schema-types',
     {
-      resolve: `gatsby-source-filesystem`,
+      resolve: 'gatsby-source-filesystem',
       options: {
-        name: `images`,
+        name: 'images',
         path: `${__dirname}/src/images`
       }
     },
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
+    'gatsby-transformer-sharp',
+    'gatsby-plugin-sharp',
     {
-      resolve: `gatsby-plugin-manifest`,
+      resolve: 'gatsby-plugin-manifest',
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
-        start_url: `/`,
-        background_color: `#663399`,
-        theme_color: `#663399`,
-        display: `minimal-ui`,
-        icon: `src/images/gatsby-icon.png` // This path is relative to the root of the site.
+        name: 'gatsby-starter-default',
+        short_name: 'starter',
+        start_url: '/',
+        background_color: '#663399',
+        theme_color: '#663399',
+        display: 'minimal-ui',
+        icon: 'src/images/gatsby-icon.png' // This path is relative to the root of the site.
       }
     },
     {
-      resolve: `gatsby-source-filesystem`,
+      resolve: 'gatsby-source-filesystem',
       options: {
         path: `${__dirname}/src/docs`,
         name: 'docs'
       }
     },
     {
-      resolve: `gatsby-transformer-remark`,
+      resolve: 'gatsby-transformer-remark',
       options: {
         plugins: [
           {
-            resolve: `gatsby-remark-prismjs`,
+            resolve: 'gatsby-remark-prismjs',
             options: {
               classPrefix: 'language-',
               inlineCodeMarker: null,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,7 @@ exports.createPages = async ({ actions, graphql }) => {
   const { createPage } = actions
 
   const pageTemplate = path.resolve(
-    `src/components/pageTemplate.js`
+    'src/components/pageTemplate.js'
   )
 
   const result = await graphql(`
@@ -40,7 +40,7 @@ exports.createPages = async ({ actions, graphql }) => {
 
 // Replacing '/' would result in empty string which is invalid
 const replacePath = path =>
-  path === `/` ? path : path.replace(/\/$/, ``)
+  path === '/' ? path : path.replace(/\/$/, '')
 
 // Remove the trailing space for each page
 exports.onCreatePage = ({ page, actions }) => {

--- a/plugins/schema-types/gatsby-node.js
+++ b/plugins/schema-types/gatsby-node.js
@@ -8,7 +8,7 @@ exports.createPages = ({ boundActionCreators }) => {
     createPage({
       path: typeData.id,
       component: path.resolve(
-        `src/components/TypeDescription.js`
+        'src/components/TypeDescription.js'
       ),
       // Send additional data to page from JSON (or query inside template)
       context: typeData

--- a/src/components/Meta.js
+++ b/src/components/Meta.js
@@ -21,7 +21,7 @@ function Meta({ description, lang, title }) {
             }`}
             meta={[
               {
-                name: `description`,
+                name: 'description',
                 content: metaDescription
               }
             ]}
@@ -33,7 +33,7 @@ function Meta({ description, lang, title }) {
 }
 
 Meta.defaultProps = {
-  lang: `en`,
+  lang: 'en',
   meta: [],
   keywords: []
 }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -35,7 +35,7 @@ Header.propTypes = {
 }
 
 Header.defaultProps = {
-  siteTitle: ``
+  siteTitle: ''
 }
 
 export default Header

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,5 @@
 import React from 'react'
-
 import Layout from '../components/layout'
-import Meta from '../components/Meta'
 
 const NotFoundPage = () => (
   <Layout title="Page not found">


### PR DESCRIPTION
This patch makes the usage of quote marks consistent. Rather than sometimes using backticks and sometimes using single quotes, we're always using single quotes.

I know the intermittent usage of backticks is a "gatsby thing", but it does not align with our general way of writing code.