### PR TITLE
chore: make `npm run format` format everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "develop": "gatsby develop",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "start": "npm run develop",
-    "format": "prettier --write \"src/**/*.js\"",
+    "format": "prettier --write *.{js,json,md} \"plugins/**/*.{js,json}\"  \"src/**/*.{js,css,md,json}\"",
     "precommit": "lint-staged"
   },
   "dependencies": {


### PR DESCRIPTION
This patch updates the `format` npm script. Previously running `format` would only format JS files in the `src` directory. Now, it'll format everything Prettier can handle.